### PR TITLE
2022-Q3-update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ data-mesh-from-source: ## Creates a new Data Mesh in Confluent Cloud then builds
 
 .PHONY: data-mesh
 data-mesh: ## Creates a new Data Mesh in Confluent Cloud then builds and runs the demo
+	@./scripts/validate-docker.sh
 	@./scripts/create-data-mesh.sh
 	@make run-docker
 

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ run-docker: ## Run the demo in Docker
 .PHONY: data-mesh-from-source
 data-mesh-from-source: ## Creates a new Data Mesh in Confluent Cloud then builds and runs the demo
 	@./scripts/create-data-mesh.sh
-	@make run-local
+	@make run-from-source
 
 .PHONY: data-mesh
 data-mesh: ## Creates a new Data Mesh in Confluent Cloud then builds and runs the demo

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = 'io.confluent.demo'
-version = '0.0.51'
+version = '0.0.52'
 
 repositories {
 	mavenCentral()

--- a/scripts/destroy-data-mesh.sh
+++ b/scripts/destroy-data-mesh.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 # ccloud_library contains function for creating
@@ -51,7 +52,14 @@ ccloud::validate_ccloud_config $CONFIG_FILE || exit 1
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 ccloud::generate_configs $CONFIG_FILE > /dev/null
 source delta_configs/env.delta
-SERVICE_ACCOUNT_ID=$(ccloud::get_service_account $CLOUD_KEY) || exit 1
+SERVICE_ACCOUNT_ID=$(ccloud::get_service_account $CLOUD_KEY)
+
+if [ -z "${SERVICE_ACCOUNT_ID+x}" ]; then
+  echo "SERVICE_ACCOUNT_ID is blank"
+  exit 1
+else
+  echo "Service account id = $SERVICE_ACCOUNT_ID"
+fi
 
 echo
 REST_API_KEY=$( grep "^confluent.cloud.auth.key" $CONFIG_FILE | awk -F'=' '{print $2;}' )

--- a/scripts/helper.sh
+++ b/scripts/helper.sh
@@ -68,11 +68,11 @@ function create_ksqldb_app() {
   MAX_WAIT=720
   echo "Waiting up to $MAX_WAIT seconds for Confluent Cloud ksqlDB cluster to be UP"
   ccloud::retry $MAX_WAIT ccloud::validate_ccloud_ksqldb_endpoint_ready $KSQLDB_ENDPOINT || exit 1
-  CMD="confluent ksql app list -o json | jq -r '.[].id'"
+  CMD="confluent ksql cluster list -o json | jq -r '.[].id'"
   ksqlDBAppId=$(eval $CMD) \
     && print_pass "Retrieved ksqlDB application ID: $ksqlDBAppId" \
     || exit_with_error -c $? -n "$NAME" -m "$CMD" -l $(($LINENO -3))
-  CMD="confluent ksql app configure-acls $ksqlDBAppId stocktrades pageviews users"
+  CMD="confluent ksql cluster configure-acls $ksqlDBAppId stocktrades pageviews users"
   $CMD \
     && print_pass "$CMD" \
     || exit_with_error -c $? -n "$NAME" -m "$CMD" -l $(($LINENO -3))
@@ -113,7 +113,7 @@ function augment_config_file() {
   KAFKA_CLUSTER_NAME=${KAFKA_CLUSTER_NAME:-"demo-kafka-cluster-$SERVICE_ACCOUNT_ID"}
   KAFKA_CLUSTER_ID=$(confluent kafka cluster list -o json | jq -r 'map(select(.name | startswith("'"$KAFKA_CLUSTER_NAME"'"))) | .[].id')
   SCHEMA_REGISTRY_ID=$(confluent schema-registry cluster describe -o json | jq -r ".cluster_id")
-  KSQLDB_ID=$(confluent ksql app list -o json | jq -r 'map(select(.name == "demo-ksqldb-'"$SERVICE_ACCOUNT_ID"'")) | .[].id')
+  KSQLDB_ID=$(confluent ksql cluster list -o json | jq -r 'map(select(.name == "demo-ksqldb-'"$SERVICE_ACCOUNT_ID"'")) | .[].id')
 
   # Create credentials for the cloud resource for the Connector REST API
   REST_API_AUTH_USER_INFO=$(confluent api-key create --resource cloud -o json) || exit 1

--- a/scripts/validate-docker.sh
+++ b/scripts/validate-docker.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+images=$(docker images);
+if [ $? -ne 0 ]; then 
+  echo "Docker returned an error code. Validate that it is running."
+  exit 1; 
+fi


### PR DESCRIPTION
- Updated scripts to use the latest confluent CLI (2.22.0). Fixed deprecation warnings.
- Fixed the make run-from-source (had a misnomer in the Make file).
- Tested the creation and destruction of data mesh using run-from-source.
