### PR TITLE
Update create-data-mesh.sh

### DIFF
--- a/scripts/create-data-mesh.sh
+++ b/scripts/create-data-mesh.sh
@@ -8,7 +8,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 # Confluent Cloud resources
 # For now a copy of ccloud_library is copied locally until examples
 #		CLI-1399 is tested and merged
-curl -sS -o ${DIR}/ccloud_library.sh https://raw.githubusercontent.com/confluentinc/examples/CLI_version_3.0_Update/utils/ccloud_library.sh
+curl -sS -o ${DIR}/ccloud_library.sh https://raw.githubusercontent.com/confluentinc/examples/7.3.1-post/utils/ccloud_library.sh
 source ${DIR}/ccloud_library.sh
 source ${DIR}/helper.sh
 


### PR DESCRIPTION
The existing URL for ccloud_library.sh was obsolete and now is replaced with a working one.