### PR TITLE
updated maven url

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ version = '0.0.52'
 repositories {
 	mavenCentral()
 	maven {
-		url "https://ksqldb-maven.s3.amazonaws.com/maven/"
+		url "https://ksqldb-mvns.s3.amazonaws.com/maven/"
 	}
 	maven {
 		url "https://jenkins-confluent-packages-beta-maven.s3.amazonaws.com/7.0.0-beta210811194853/1/maven/"


### PR DESCRIPTION
Project Capsaicin: Move buckets from cc-root-1 to ksql specific account.

Old Object: https://ksqldb-maven.s3.amazonaws.com/maven/io/confluent/ksql/ksqldb-cli/0.29.0-rc3/ksqldb-cli-0.29.0-rc3.jar
New Object: https://ksqldb-mvns.s3.amazonaws.com/maven/io/confluent/ksql/ksqldb-cli/0.29.0-rc3/ksqldb-cli-0.29.0-rc3.jar

Both are publicly accessible/downloadable.